### PR TITLE
add Slack group - Data Hackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Where to discover new tools and discuss about existing ones.
 
 ## Slack
 
+* [Data Hackers](https://datahackers.com.br/slack/)
 * [Kubeflow Workspace](https://kubeflow.slack.com/#/)
 * [MLOps Community Wokspace](https://mlops-community.slack.com)
 


### PR DESCRIPTION
## What is this tool for?

Add a Data Hackers Slack group. This is a brazilian group that works with any Data-like products, such as MLOps, DataOps, etc.

## What's the difference between this tool and similar ones?

- Slack group with over 29k brazilian professionals

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
