### PR TITLE
Add Guild AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 *Tools for managing model lifecycle (tracking experiments, parameters and metrics).*
 
 * [Comet](https://www.comet.ml/site/) - Track your datasets, code changes, experimentation history, and models.
+* [Guild AI](https://guild.ai/) - Open source experiment tracking, pipeline automation, and hyperparameter tuning.
 * [Mlflow](https://mlflow.org/) - Open source platform for the machine learning lifecycle.
 * [ModelDB](https://github.com/VertaAI/modeldb/) - Open source ML model versioning, metadata, and experiment management.
 * [Neptune AI](https://neptune.ai/) - The most lightweight experiment management tool that fits any workflow.
@@ -230,7 +231,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 
 *Tools for performing visual analysis and debugging of ML/DL models.*
 
-* [Evidently](https://github.com/evidentlyai/evidently) - Interactive reports to analyze ML models during validation or production monitoring. 
+* [Evidently](https://github.com/evidentlyai/evidently) - Interactive reports to analyze ML models during validation or production monitoring.
 * [Manifold](https://github.com/uber/manifold) - A model-agnostic visual debugging tool for machine learning.
 * [Netron](https://github.com/lutzroeder/netron) - Visualizer for neural network, deep learning, and machine learning models.
 * [Yellowbrick](https://github.com/DistrictDataLabs/yellowbrick) - Visual analysis and diagnostic tools to facilitate machine learning model selection.


### PR DESCRIPTION
## What is this tool for?

Guild AI is used to run, track, and compare machine learning experiments. Other features include hyperparameter tuning, pipeline automation, parallel execution, and remote operations.

## What's the difference between this tool and similar ones?

Guild AI differs from other ML experiment tracking tools in various ways:

- Guild does not require changes to code and does not introduce library dependencies. This gets teams running faster as there's no need to modify work or adopt additional technology components.
- Guild stores experiments on disk rather than in a database. This again keeps setup simple and avoids operational dependencies on more software. Often teams don't have the bandwidth to deal with managing additional components, which makes Guild a good fit in such cases.
- Guild integrates with best-of-breed tools for hyperparameter tuning support, visualization, and diffing.

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
