### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Argo](https://github.com/argoproj/argo) - Open source container-native workflow engine for orchestrating parallel jobs on Kubernetes.
 * [Automate Studio](https://www.veritone.com/applications/automate-studio/) - Rapidly build & deploy AI-powered workflows.
 * [Couler](https://github.com/couler-proj/couler) - Unified interface for constructing and managing workflows on different workflow engines.
+* [dstack](https://github.com/dstackai/dstack) - An open-core tool to automate data and training workflows.
 * [Flyte](https://flyte.org/) - Easy to create concurrent, scalable, and maintainable workflows for machine learning.
 * [Kale](https://github.com/kubeflow-kale/kale) - Aims at simplifying the Data Science experience of deploying Kubeflow Pipelines workflows.
 * [Kedro](https://github.com/quantumblacklabs/kedro) - Library that implements software engineering best-practice for data and ML pipelines.


### PR DESCRIPTION
Added dstack to Workflow Tools

## What is this tool for?

dstack allows you to define workflows and infrastructure they need as code. When you run workflows, the tool provisions infrastructure either in your cloud account or using your own hardware. All output data and model artifacts are versioned and can be reused in other workflows.

## What's the difference between this tool and similar ones?

The main use case for dstack is building data and training pipelines.
Comparable tools include KubeFlow and AirFlow.
Both KubeFlow and AirFLow are designed for data and ML engineers in the first place and require a lot of effort to set them up. For example, KubeFlow requires a K8S cluster, and AirFlow requires engineers to maintain it.
Airflow wasn't designed for machine learning. With Airflow, there is no a central repository of output artifacts such as data and models. Instead every workflow author decides herself on where to put the data. With dstack, data artifacts are the 1-st class citizens. Because of that dstack is perfect for organizing a repository of artifacts and their reuse in other workflows.

To a certain extent, dstack is also comparable with other categories:

1. End-to-end platforms, such as Google Vertex AI and SageMaker. In this regard, dstack is a lot more lightweight, and also supports multiple cloud vendors.
2. CI/CD for Machine Learning, e.g. CML. In this regard, dstack offers similar functionality but unlike CML, dstack integrates with computing providers such as AWS, and can provision infrastructure on-demand.

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
