### PR TITLE
Added CsvPath Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Amundsen](https://www.amundsen.io/) - Data discovery and metadata engine for improving the productivity when interacting with data.
 * [Apache Atlas](https://atlas.apache.org) - Provides open metadata management and governance capabilities to build a data catalog.
 * [CKAN](https://github.com/ckan/ckan) - Open-source DMS (data management system) for powering data hubs and data portals.
+* [CsvPath Framework](https://www.csvpath.org) - Data preboarding infrastructure that sits as a trusted publisher between MFT and the data lake.
 * [DataHub](https://github.com/linkedin/datahub) - LinkedIn's generalized metadata search & discovery tool.
 * [Magda](https://github.com/magda-io/magda) - A federated, open-source data catalog for all your big data and small data.
 * [Metacat](https://github.com/Netflix/metacat) - Unified metadata exploration API service for Hive, RDS, Teradata, Redshift, S3 and Cassandra.


### PR DESCRIPTION
CsvPath acts as a trusted publisher representing a verified version of the world to the data lake, after assigning a durable identity, performing validation,  canonicalization and upgrading, and staging in an immutable, idempotent archive.

## What is this tool for?

CsvPath is preboarding framework that intermediates delimited data entering the organization to validate, identify, upgrade, and archive data before it is made available to downstream consumers. It automates the process of trusted publishing and makes it operationally scalable to any number of data partners. And it includes the most advanced rules- and schema-based delimited and tabular data validation language available.

## What's the difference between this tool and similar ones?

There are relatively few commercial or open source preboarding tools. Most companies roll their own. The two leading ones are SaaS platforms for user-self service delimited file uploading; whereas, CsvPath is focused on automated DataOps infrastructure use cases. CKAN + Frictionless Framework are similar, but don't focus on exactly the same use cases and take different approaches. CsvPath includes a CKAN integration to better enable CKAN-like use cases, but that is not the main focus. Terra.bio's DataRepo has a similar trusted publisher position in the world of biotech; though, it is much more UI- and curation-oriented.

Enumerate comparisons.

- OneSchema
- FlatFile
- CKAN

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
