### PR TITLE
Add Simplismart

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Quix](https://quix.io) - Serverless platform for processing data streams in real-time with machine learning models.
 * [Rune](https://github.com/hotg-ai/rune) - Provides containers to encapsulate and deploy EdgeML pipelines and applications.
 * [Seldon](https://www.seldon.io/) - Take your ML projects from POC to production with maximum efficiency and minimal risk.
+* [Simplismart](https://www.simplismart.ai/) - Fastest GenAI inference engine that's completely cloud-agnostic and model-agnostic.
 * [Streamlit](https://github.com/streamlit/streamlit) - Lets you create apps for your ML projects with deceptively simple Python scripts.
 * [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving) - Flexible, high-performance serving system for ML models, designed for production.
 * [TorchServe](https://github.com/pytorch/serve) - A flexible and easy to use tool for serving PyTorch models.


### PR DESCRIPTION
## What is this tool for?

Simplismart is an MLOps platform that enables enterprises to fine-tune, deploy, and optimize GenAI models across the NVIDIA chipset. It ensures seamless model deployment by providing a model-agnostic, cloud-agnostic infrastructure that enhances performance, cost efficiency, and observability while maintaining enterprise control over data privacy and customization.

## What's the difference between this tool and similar ones?

Unlike hyperscalers that enforce platform dependence, Simplismart provides a flexible and efficient inference layer that enterprises can integrate into their existing workflows. It offers performance benefits comparable to proprietary solutions but with greater transparency, cost efficiency, and adaptability.

Enumerate comparisons.

[Baseten](https://www.baseten.co/)
[Anyscale](https://www.anyscale.com/)
[Together AI](https://www.together.ai/)

Anyone who agrees with this pull request could submit an *Approve* review to it.
