### PR TITLE
Add Skyulf to the list of ML tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [SigOpt](https://sigopt.com/) - A platform that makes it easy to track runs, visualize training, and scale hyperparameter tuning.
 * [TrueFoundry](https://www.truefoundry.com) - A Cloud-native MLOps Platform over Kubernetes to simplify training and serving of ML Models.
 * [Valohai](https://valohai.com/) - Takes you from POC to production while managing the whole model lifecycle.
+* [Skyulf](https://github.com/flyingriverhorse/Skyulf) – A stateless, graph-based ML pipeline engine. Features a "Calculator/Applier" architecture for lightweight deployment, structural leakage prevention, and a visual node editor.
 
 ## Model Fairness and Privacy
 


### PR DESCRIPTION
## What is this tool for?
**Skyulf** is an open-source MLOps platform and a standalone Python library (`skyulf-core`) for building **leakage-proof, stateless ML pipelines**. It separates training logic from inference, allowing models to be saved as version-agnostic JSON artifacts instead of problematic Python pickles. It also includes a Polars-powered automated EDA engine.

## Differences?
*   **vs Scikit-learn:** Skyulf pipelines are stateless (JSON deployment) and architecturally enforce leakage prevention (SplitDataset), whereas Scikit-learn relies on user discipline and heavy pickles.
*   **vs MLflow:** Skyulf builds the pipeline logic and architecture; MLflow tracks the results.
*   **vs Cloud:** Skyulf is local-first/self-hosted, requiring no data upload.

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
