### PR TITLE
Add tandemn-tuna

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Rune](https://github.com/hotg-ai/rune) - Provides containers to encapsulate and deploy EdgeML pipelines and applications.
 * [Seldon](https://www.seldon.io/) - Take your ML projects from POC to production with maximum efficiency and minimal risk.
 * [Streamlit](https://github.com/streamlit/streamlit) - Lets you create apps for your ML projects with deceptively simple Python scripts.
+* [Tuna](https://github.com/Tandemn-Labs/tandemn-tuna) - Hybrid GPU inference orchestrator that routes between spot and serverless GPUs to reduce costs and cold starts.
 * [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving) - Flexible, high-performance serving system for ML models, designed for production.
 * [TorchServe](https://github.com/pytorch/serve) - A flexible and easy to use tool for serving PyTorch models.
 * [Triton Inference Server](https://github.com/triton-inference-server/server) - Provides an optimized cloud and edge inferencing solution.


### PR DESCRIPTION
Add [Tuna](https://github.com/Tandemn-Labs/tandemn-tuna) to the Model Serving section.

Tuna is a hybrid GPU inference orchestrator that routes traffic between spot and serverless GPU providers (Modal, RunPod, Cloud Run, Baseten) to reduce costs and eliminate cold starts. It uses vLLM under the hood and supports multi-provider deployments with a single CLI command.