### PR TITLE
Add realtime-ai-serve to Model Serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Opyrator](https://github.com/ml-tooling/opyrator) - Turns your ML code into microservices with web API, interactive GUI, and more.
 * [PredictionIO](https://github.com/apache/predictionio) - Event collection, deployment of algorithms, evaluation, querying predictive results via APIs.
 * [Quix](https://quix.io) - Serverless platform for processing data streams in real-time with machine learning models.
+* [realtime-ai-serve](https://github.com/anmoldhingra1/realtime-ai-serve) - A low-latency streaming inference server with token streaming, request batching, model hot-swapping, and async middleware. Built on asyncio.
 * [Rune](https://github.com/hotg-ai/rune) - Provides containers to encapsulate and deploy EdgeML pipelines and applications.
 * [Seldon](https://www.seldon.io/) - Take your ML projects from POC to production with maximum efficiency and minimal risk.
 * [Streamlit](https://github.com/streamlit/streamlit) - Lets you create apps for your ML projects with deceptively simple Python scripts.


### PR DESCRIPTION
## Addition

[realtime-ai-serve](https://github.com/anmoldhingra1/realtime-ai-serve) — A low-latency streaming inference server for AI models.

**Key features**:
- Token-by-token streaming via server-sent events
- Dynamic request batching with priority queues for GPU-efficient processing
- Model hot-swapping with versioned zero-downtime transitions
- Pluggable middleware chain (rate limiting, logging, metrics)
- Built on asyncio and aiohttp

46 tests, CI passing across Python 3.9–3.12, MIT licensed.

Placed alphabetically in the Model Serving section.