### PR TITLE
Add Jupyter Notebook Validator Operator to Model Testing & Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 *Tools for testing and validating models.*
 
 * [Deepchecks](https://github.com/deepchecks/deepchecks) - Open-source package for validating ML models & data, with various checks and suites.
+* [Jupyter Notebook Validator Operator](https://github.com/tosin2013/jupyter-notebook-validator-operator) - Kubernetes-native operator for automated notebook execution, golden notebook comparison, and model-aware validation in MLOps workflows.
 * [Starwhale](https://github.com/star-whale/starwhale) - An MLOps/LLMOps platform for model building, evaluation, and fine-tuning.
 * [Trubrics](https://github.com/trubrics/trubrics-sdk) - Validate machine learning with data science and domain expert feedback.
 


### PR DESCRIPTION
## Summary
Adds [Jupyter Notebook Validator Operator](https://github.com/tosin2013/jupyter-notebook-validator-operator) to **Model Testing & Validation**.

## About the project
Kubernetes operator for automated notebook validation: execution with Papermill, golden notebook comparison, and model-aware validation in MLOps workflows. Available on [OperatorHub.io](https://operatorhub.io/operator/jupyter-notebook-validator-operator).

Made with [Cursor](https://cursor.com)