### PR TITLE
Add Matyan

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Guild AI](https://guild.ai/) - Open source experiment tracking, pipeline automation, and hyperparameter tuning.
 * [Keepsake](https://github.com/replicate/keepsake) - Version control for machine learning with support to Amazon S3 and Google Cloud Storage.
 * [Losswise](https://losswise.com) - Makes it easy to track the progress of a machine learning project.
+* [Matyan](https://github.com/4gt-104/matyan-core) - Scalable, self-hosted ML experiment tracker with Aim-compatible UI/SDK, built on FoundationDB and Kafka.
 * [MLflow](https://mlflow.org/) - Open source platform for the machine learning lifecycle.
 * [ModelDB](https://github.com/VertaAI/modeldb/) - Open source ML model versioning, metadata, and experiment management.
 * [Neptune AI](https://neptune.ai/) - The most lightweight experiment management tool that fits any workflow.


### PR DESCRIPTION
# What is this tool for?

[Matyan](https://github.com/4gt-104/matyan-core) is a high-performance, self-hosted ML experiment tracking stack designed for horizontal scalability. It is a fork of [Aim](https://github.com/aimhubio/aim) that preserves the original React UI and Python SDK while completely re-engineering the storage and ingestion layers.

Key Features:

* Metadata & Metrics Tracking: Logs hyperparameters, metrics, images, audio, and distributions with a beautiful, high-performance UI.
* Distributed Storage: Uses FoundationDB for ACID-compliant, distributed metadata storage, enabling the system to handle tens of thousands of runs.
* Event-Driven Ingestion: Implements a Kafka-based pipeline to decouple training scripts from database pressure, preventing write-stalls and backpressure on GPUs.
* Multi-Cloud Artifacts: Native support for S3-compatible storage, Azure Blob Storage, and GCS.
* Kubernetes Native: Ships with a Helm chart for deploying stateless, horizontally scalable services.

# What's the difference between this tool and similar ones?

Compared to existing tools, Matyan focuses on removing the "Scaling Wall" often hit in on-prem or hybrid-cloud environments:

* vs. Aim: While Aim uses a single-node RocksDB/SQLite backend, Matyan uses FoundationDB. This moves the tool from a single-researcher utility to a high-availability infrastructure that supports large teams without risk of database corruption or file-locking bottlenecks.
* vs. MLflow: Matyan offers a much more responsive UI and advanced visualization (grouping, aggregation, and subplots) that remains performant even when querying thousands of experiments simultaneously.
* vs. Weights & Biases: Matyan is fully open-source and self-hosted. It provides the high-end features of a managed platform while ensuring data sovereignty and eliminating egress costs or per-seat pricing.
* vs. TensorBoard: Matyan treats tracked parameters as first-class citizens, allowing for complex querying and comparison across experiments without encoding metadata into run names.

