### PR TITLE
Add Agentic Engineering Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ Where to discover new tools and discuss about existing ones.
 
 ## Websites
 
+* [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems: RAG, AI agents, LLM-powered products, agent orchestration. Free to post, free to browse.
 * [A guide to MLOps](https://mlops.swiss-ai-center.ch/)
 * [Feature Stores for ML](http://featurestore.org/)
 * [Made with ML](https://github.com/GokuMohandas/Made-With-ML)

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Where to discover new tools and discuss about existing ones.
 
 ## Websites
 
-* [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems: RAG, AI agents, LLM-powered products, agent orchestration. Free to post, free to browse.
+* [Agentic Engineering Jobs](https://agentic-engineering-jobs.com)
 * [A guide to MLOps](https://mlops.swiss-ai-center.ch/)
 * [Feature Stores for ML](http://featurestore.org/)
 * [Made with ML](https://github.com/GokuMohandas/Made-With-ML)


### PR DESCRIPTION
Adding https://agentic-engineering-jobs.com to the Websites section under Resources.

It's a job board for engineers building agentic systems — RAG pipelines, AI agents, LLM-powered products, agent orchestration. Many of these roles overlap with MLOps practitioners deploying LLM-powered systems in production.

- 500+ active listings
- Free to post for companies, free to browse for job seekers
- Inserted in alphabetical order under ## Websites

Followed the contribution guidelines (one link, single section, alphabetical, format with period). Happy to adjust if anything's off.