### PR TITLE
Add ModelSpec — open standard for AI model runtime requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [LocalAI](https://github.com/mudler/LocalAI) - Drop-in replacement REST API that’s compatible with OpenAI API specifications for inferencing.
 * [Merlin](https://github.com/gojek/merlin) - A platform for deploying and serving machine learning models.
 * [MLEM](https://github.com/iterative/mlem) - Version and deploy your ML models following GitOps principles.
+* [ModelSpec](https://github.com/paralleliq/modelspec) - Open declarative standard for describing AI model runtime requirements, scaling targets, and governance constraints in a version-controlled YAML format.
 * [Opyrator](https://github.com/ml-tooling/opyrator) - Turns your ML code into microservices with web API, interactive GUI, and more.
 * [PredictionIO](https://github.com/apache/predictionio) - Event collection, deployment of algorithms, evaluation, querying predictive results via APIs.
 * [Quix](https://quix.io) - Serverless platform for processing data streams in real-time with machine learning models.


### PR DESCRIPTION
ModelSpec is an open declarative standard for describing AI model runtime requirements, scaling targets, and governance constraints in a version-controlled YAML format. Fits in the Model Serving section alongside tools like MLEM and KFServing.