### PR TITLE
Add Falsify to Model Testing & Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,8 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 *Tools for testing and validating models.*
 
 * [Deepchecks](https://github.com/deepchecks/deepchecks) - Open-source package for validating ML models & data, with various checks and suites.
-* [Starwhale](https://github.com/star-whale/starwhale) - An MLOps/LLMOps platform for model building, evaluation, and fine-tuning.
+* [Falsify](https://github.com/sk8ordie84/falsify) - CLI to pre-register ML accuracy claims with SHA-256 before the experiment runs; tampered specs exit 3 in CI.
+* * [Starwhale](https://github.com/star-whale/starwhale) - An MLOps/LLMOps platform for model building, evaluation, and fine-tuning.
 * [Trubrics](https://github.com/trubrics/trubrics-sdk) - Validate machine learning with data science and domain expert feedback.
 
 ## Optimization Tools

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 *Tools for testing and validating models.*
 
 * [Deepchecks](https://github.com/deepchecks/deepchecks) - Open-source package for validating ML models & data, with various checks and suites.
+* [Falsify (PRML)](https://github.com/studio-11-co/falsify) - Open spec (Pre-Registered ML Manifest) for committing ML evaluation claims to a SHA-256 hash before the run; the cryptographic receipt is verifiable in CI without depending on the registry.
 * [Starwhale](https://github.com/star-whale/starwhale) - An MLOps/LLMOps platform for model building, evaluation, and fine-tuning.
 * [Trubrics](https://github.com/trubrics/trubrics-sdk) - Validate machine learning with data science and domain expert feedback.
 


### PR DESCRIPTION
## What is this tool for?

[Falsify](https://github.com/sk8ordie84/falsify) is an open-source CLI for pre-registering ML accuracy claims. You declare a metric, threshold, dataset hash, and seed, it writes a SHA-256 manifest *before* the experiment runs, and verifies that the locked spec wasn't silently edited after seeing the result. If the spec is tampered, the next run exits with code 3 and CI refuses to produce a verdict.

* MIT licensed, Python 3.11+
* Single-file (~3925 LOC), stdlib + pyyaml only
* 518 tests passing
* Includes a GitHub Action, pre-commit hooks, MCP server, and Claude Code skills
* Site: https://falsify.dev | Demo (90s): https://youtu.be/vVZTNeak5PA

## What's the difference between this tool and similar ones?

Falsify is a *contract layer* on top of existing model-testing tools, not a replacement.

* **Deepchecks** validates models and data with statistical/sanity checks. Falsify hashes the *claim* about what those checks must pass before they run.
* **Starwhale** is a full MLOps/LLMOps platform for builds, evals, and fine-tuning. Falsify composes underneath as a one-command pre-deploy receipt.
* **Trubrics** captures qualitative feedback from data scientists and domain experts. Falsify captures the cryptographic commitment to the quantitative threshold.

In short: tracking and validation tools record *what happened*; falsify records *what was promised*. Both are needed.

Listed alphabetically between Deepchecks and Starwhale per the section convention. Happy to adjust the description or category if a better fit exists.

---

Anyone who agrees with this pull request could submit an *Approve* review to it.