### PR TITLE
Add FRAKMA to Machine Learning Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Edge Impulse](https://edgeimpulse.com/) - Platform for creating, optimizing, and deploying AI/ML algorithms for edge devices.
 * [envd](https://github.com/tensorchord/envd) - Machine learning development environment for data science and AI/ML engineering teams.
 * [FedML](https://fedml.ai/) - Simplifies the workflow of federated learning anywhere at any scale.
+* [FRAKMA](https://frakma.io) - GitOps-native, self-hosted MLOps platform on Kubernetes; bundles OpenFaaS, Ray, Argo CD, KServe, MLflow and Airflow under a single CRD.
 * [Gradient](https://gradient.paperspace.com/) - Multicloud CI/CD and MLOps platform for machine learning teams.
 * [H2O](https://www.h2o.ai/) - Open source leader in AI with a mission to democratize AI for everyone.
 * [Hopsworks](https://www.hopsworks.ai/) - Open-source platform for developing and operating machine learning models at scale.


### PR DESCRIPTION
Adds [FRAKMA](https://github.com/warble-tech/warble-oss), a GitOps-native, self-hosted MLOps platform on Kubernetes (Apache 2.0).

It bundles OpenFaaS, Ray, Argo CD, KServe, MLflow and Airflow under a single `WarbleApp` CRD, with reference IaC for AKS in-tree (GKE/EKS coming).

- Repo: https://github.com/warble-tech/warble-oss
- Site: https://frakma.io
- License: Apache-2.0

Inserted alphabetically in the **Machine Learning Platform** section between FedML and Gradient. Description kept under one line, ending with a period to match the section style. Happy to adjust wording or section if you'd prefer.