### PR TITLE
Add GenOps Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 
 * [ClearML](https://github.com/allegroai/clearml) - Auto-Magical CI/CD to streamline your ML workflow.
 * [CML](https://github.com/iterative/cml) - Open-source library for implementing CI/CD in machine learning projects.
+* [GenOps Framework](https://github.com/neerazz/genops-framework) - Open-source CI/CD governance framework for embedding generative AI agents into production pipelines with risk-scored deployment gates.
 * [KitOps](https://github.com/jozu-ai/kitops) – Open source MLOps project that eases model handoffs between data scientist and DevOps. 
 
 ## Cron Job Monitoring


### PR DESCRIPTION
Adds [GenOps Framework](https://github.com/neerazz/genops-framework) to the CI/CD for Machine Learning section.

Open-source CI/CD governance framework for embedding generative AI agents into production pipelines. Provides risk-scored deployment gates, LLM audit logging, and policy-as-code controls. Companion to the peer-reviewed JISEM paper [GenOps: Operationalizing Generative AI](https://jisem-journal.com/article/view/14322).