### PR TITLE
Add ONNX2Anything — browser-based ONNX model converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Koalas](https://github.com/databricks/koalas) - Pandas API on Apache Spark. Makes data scientists more productive when interacting with big data.
 * [Ludwig](https://github.com/uber/ludwig) - Allows users to train and test deep learning models without the need to write code.
 * [MLNotify](https://github.com/aporia-ai/mlnotify) - No need to keep checking your training, just one import line and you'll know the second it's done.
+* [ONNX2Anything](https://github.com/UnstoppableCurry/onnx2anything) - Convert ONNX models to NCNN, MNN, TNN, TFLite, CoreML and more — entirely in the browser via WebAssembly. Zero install, zero server, privacy-first.
 * [PyCaret](https://pycaret.org/) - Open source, low-code machine learning library in Python.
 * [Sagify](https://github.com/Kenza-AI/sagify) - A CLI utility to train and deploy ML/DL models on AWS SageMaker.
 * [Soopervisor](https://github.com/ploomber/soopervisor) - Export ML projects to Kubernetes (Argo workflows), Airflow, AWS Batch, and SLURM.


### PR DESCRIPTION
## What is ONNX2Anything?

**[ONNX2Anything](https://github.com/UnstoppableCurry/onnx2anything)** converts ONNX models to edge inference formats (NCNN, MNN, TNN, Tengine, Paddle Lite) entirely in the browser using WebAssembly + Pyodide.

🌐 **Live demo**: https://onnx2anything.com

## Why it belongs here

Fits perfectly in **Simplification Tools** — it eliminates the need to:
- Install SDKs, Python environments, or native compilers
- Upload models to remote servers
- Learn different CLIs for each target framework

Open the page, drop your ONNX model, download the converted file. Done.

## Checklist

- [x] The project is open source (MIT license)
- [x] The project is actively maintained
- [x] Follows alphabetical ordering (inserted between MLNotify and PyCaret)
- [x] Description is concise (one line)