### PR TITLE
Add AI Models Catalog to Other Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ Where to discover new tools and discuss about existing ones.
 * [Awesome Deep Learning](https://github.com/ChristosChristofidis/awesome-deep-learning)
 * [Awesome Game Datasets](https://github.com/leomaurodesenv/game-datasets) (includes AI content)
 * [Awesome Machine Learning](https://github.com/josephmisiti/awesome-machine-learning)
+* [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities for MLOps decision-making.
 * [Awesome MLOps](https://github.com/visenger/awesome-mlops)
 * [Awesome Production Machine Learning](https://github.com/EthicalML/awesome-production-machine-learning)
 * [Awesome Python](https://github.com/vinta/awesome-python)


### PR DESCRIPTION
## Addition

- **Name:** AI Models Catalog
- **URL:** https://github.com/i-need-token/ai-models
- **Category:** Other Lists

## Description

Structured catalog of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Useful for MLOps decision-making when selecting models for production deployment.

## Why this belongs in the list

- **Model selection for MLOps**: Covers pricing, context windows, tool calling, reasoning, and structured output for 4,587+ models — critical data for production model selection
- **Machine-readable formats**: Available as JSON, CSV, YAML, and npm package for integration into MLOps pipelines
- **First-party data only**: All data sourced from provider APIs and official documentation
- **Interactive catalog**: Live comparison tool at https://i-need-token.github.io/ai-models/
- **Open source**: MIT licensed with automated scraping pipeline

## Checklist

- [x] Entry follows the existing format
- [x] Added to the correct category (Other Lists)
- [x] Not a duplicate of existing entries