### PR TITLE
Add piqc — GPU waste scanner for Kubernetes inference clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Nebullvm](https://github.com/nebuly-ai/nebullvm) - Easy-to-use library to boost AI inference.
 * [Nos](https://github.com/nebuly-ai/nos) - Open-source module for running AI workloads on Kubernetes in an optimized way.
 * [Petastorm](https://github.com/uber/petastorm) - Enables single machine or distributed training and evaluation of deep learning models.
+* [piqc](https://github.com/paralleliq/piqc) - Read-only GPU waste scanner for Kubernetes inference clusters. Detects tier misplacement, idle capacity, OOM risk, and CPU:GPU imbalance.
 * [Rapids](https://rapids.ai/index.html) - Gives the ability to execute end-to-end data science and analytics pipelines entirely on GPUs.
 * [Ray](https://github.com/ray-project/ray) - Fast and simple framework for building and running distributed applications.
 * [Singa](http://singa.apache.org/en/index.html) - Apache top level project, focusing on distributed training of DL and ML models.


### PR DESCRIPTION
**piqc** is an open-source, read-only GPU waste scanner for Kubernetes inference clusters.

It deploys as a Kubernetes Job (no write permissions required), introspects running vLLM workloads, and reports four waste patterns that typically account for 20–40% of GPU spend in production inference:

- **Tier misplacement** — model running on a GPU with more memory or compute than it needs
- **Dark capacity** — GPU allocated to a deployment serving no live traffic
- **OOM risk** — model approaching its GPU memory ceiling
- **CPU:GPU imbalance** — CPU saturation throttling GPU throughput in agentic/multi-step workloads

Apache 2.0. https://github.com/paralleliq/piqc

I've placed it in **Optimization Tools**, between Petastorm and Rapids, which fits the section's description of "optimization tools related to model scalability in production."