### PR TITLE
Add Inference Labs to Model Serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Gradio](https://github.com/gradio-app/gradio) - Create customizable UI components around your models.
 * [GraphPipe](https://oracle.github.io/graphpipe) - Machine learning model deployment made simple.
 * [Hydrosphere](https://github.com/Hydrospheredata/hydro-serving) - Platform for deploying your Machine Learning to production.
+* [Inference Labs](https://inference-labs.com) - Vendor-neutral routing and evaluation layer for production LLM inference across OpenAI/Azure, Anthropic, Google, and AWS Bedrock. Policy-based model selection (cost/quality/latency), caching, and trace-to-dataset export workflows.
 * [KFServing](https://github.com/kubeflow/kfserving) - Kubernetes custom resource definition for serving ML models on arbitrary frameworks.
 * [LocalAI](https://github.com/mudler/LocalAI) - Drop-in replacement REST API that’s compatible with OpenAI API specifications for inferencing.
 * [Merlin](https://github.com/gojek/merlin) - A platform for deploying and serving machine learning models.


### PR DESCRIPTION
Hi! This PR adds [Inference Labs](https://inference-labs.com) to **Model Serving**.

Why it fits:

- Production LLM serving/routing across multiple providers (OpenAI/Azure, Anthropic, Google, Bedrock).
- Policy controls for cost, quality, and latency.
- Caching and trace/eval export for ongoing operations.

Happy to adjust wording or placement.