### PR TITLE
Add Data Workers (autonomous agents for data/ML ops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 *Tools for monitoring cron jobs (recurring jobs).*
 
 * [Cronitor](https://cronitor.io/cron-job-monitoring) - Monitor any cron job or scheduled task.
+* [Data Workers](https://github.com/DataWorkersProject/dataworkers-claw-community) - Open-source autonomous agent swarm for data/ML ops: quality monitoring, drift and anomaly detection, incident root-cause analysis, and pipeline observability. MCP-native, works with Claude Code and Cursor. Apache 2.0.
+* [Data Workers](https://github.com/DataWorkersProject/dataworkers-claw-community) - Open-source autonomous agent swarm for data/ML ops: quality monitoring, drift and anomaly detection, incident root-cause analysis, and pipeline observability. MCP-native, works with Claude Code and Cursor. Apache 2.0.
 * [HealthchecksIO](https://healthchecks.io/) - Simple and effective cron job monitoring.
 * [Heartbeat.pm](https://heartbeat.pm) - Monitoring aliveness of any sensor/cron job.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 
 * [Cronitor](https://cronitor.io/cron-job-monitoring) - Monitor any cron job or scheduled task.
 * [Data Workers](https://github.com/DataWorkersProject/dataworkers-claw-community) - Open-source autonomous agent swarm for data/ML ops: quality monitoring, drift and anomaly detection, incident root-cause analysis, and pipeline observability. MCP-native, works with Claude Code and Cursor. Apache 2.0.
-* [Data Workers](https://github.com/DataWorkersProject/dataworkers-claw-community) - Open-source autonomous agent swarm for data/ML ops: quality monitoring, drift and anomaly detection, incident root-cause analysis, and pipeline observability. MCP-native, works with Claude Code and Cursor. Apache 2.0.
 * [HealthchecksIO](https://healthchecks.io/) - Simple and effective cron job monitoring.
 * [Heartbeat.pm](https://heartbeat.pm) - Monitoring aliveness of any sensor/cron job.
 


### PR DESCRIPTION
Adding [Data Workers](https://dataworkers.io) — open-source (Apache 2.0) autonomous agent swarm for data engineering and ML ops. Fits the Monitoring section: data quality monitoring, drift/anomaly detection, incident root-cause analysis, and pipeline observability, exposed as MCP servers for Claude Code, Cursor, and any MCP client.

Repo: https://github.com/DataWorkersProject/dataworkers-claw-community