### PR TITLE
Add TWZRD Agent Intel — agent trust verification MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Sematic](https://sematic.dev) - An open-source end-to-end pipelining tool to go from laptop prototype to cloud in no time.
 * [SigOpt](https://sigopt.com/) - A platform that makes it easy to track runs, visualize training, and scale hyperparameter tuning.
 * [TrueFoundry](https://www.truefoundry.com) - A Cloud-native MLOps Platform over Kubernetes to simplify training and serving of ML Models.
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - MCP server for agent trust verification in multi-agent systems. Pre-dispatch trust scoring and signed USDC trust receipts for agent-to-agent communication reliability on Solana. Tools: resolve_agent, score_agent, get_trust_receipt, verify_trust_receipt.
 * [Valohai](https://valohai.com/) - MLOps platform for reproducible ML and LLM workflows from experimentation to production.
 
 ## Model Fairness and Privacy


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — an MCP server for agent trust verification in multi-agent systems.

Added to the **Machine Learning Platform** section, alphabetically between TrueFoundry and Valohai. This section already includes agent infrastructure tools like Neurolink (multi-provider AI agent framework with MCP support) and Cordum (AI agent control plane).

## Why it belongs here

As multi-agent systems become a production MLOps concern, trust infrastructure is a missing layer. TWZRD provides:

- **Pre-dispatch agent verification** via `resolve_agent` + `score_agent` — know who you're talking to before delegating
- **Cryptographic trust receipts** via `get_trust_receipt` — signed USDC micropayment (<1s, Solana) creating an auditable trust verification record
- **Receipt validation** via `verify_trust_receipt` — close the loop on agent identity claims

**MCP endpoint**: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP, Solana)

## Entry added

```
* [TWZRD Agent Intel](https://intel.twzrd.xyz) - MCP server for agent trust verification in multi-agent systems. Pre-dispatch trust scoring and signed USDC trust receipts for agent-to-agent communication reliability on Solana. Tools: resolve_agent, score_agent, get_trust_receipt, verify_trust_receipt.
```