### PR TITLE
Add mitos

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Knime](https://www.knime.com/) - Create and productionize data science using one easy and intuitive environment.
 * [Kubeflow](https://www.kubeflow.org/) - Making deployments of ML workflows on Kubernetes simple, portable and scalable.
 * [LynxKite](https://lynxkite.com/) - A complete graph data science platform for very large graphs and other datasets.
+* [mitos](https://github.com/mitos-run/mitos) - Snapshot-fork microVM sandboxes for AI agents on Kubernetes, forking a running Firecracker VM into parallel attempts and restoring from memory.
 * [ML Workspace](https://github.com/ml-tooling/ml-workspace) - All-in-one web-based IDE specialized for machine learning and data science.
 * [MLReef](https://github.com/MLReef/mlreef) - Open source MLOps platform that helps you collaborate, reproduce and share your ML work.
 * [Modzy](https://www.modzy.com/) - Deploy, connect, run, and monitor machine learning (ML) models in the enterprise and at the edge.


### PR DESCRIPTION
Adds [mitos](https://github.com/mitos-run/mitos) under Machine Learning Platform. Mitos provides snapshot-fork microVM sandboxes for AI agents on Kubernetes, forking a running Firecracker VM into parallel attempts and restoring from memory. Open source under Apache-2.0.

Single entry, inserted alphabetically between LynxKite and ML Workspace, description ends with a period per the contribution guide.