### PR TITLE
Add llm-speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 ## Model Serving
 
 *Tools for serving models in production.*
+- [llm-speed](https://llm-speed.com) - Crowdsourced LLM inference-speed leaderboard (tok/s, TTFT) across local and hosted backends; reproducible, signed runs.
 
 * [Banana](https://banana.dev) - Host your ML inference code on serverless GPUs and integrate it into your app with one line of code.
 * [Beam](https://beam.cloud) - Develop on serverless GPUs, deploy highly performant APIs, and rapidly prototype ML models.


### PR DESCRIPTION
Hi! Adding [llm-speed](https://llm-speed.com), a crowdsourced benchmark
of how fast LLMs actually run (decode tok/s, TTFT, latency percentiles)
across hosted APIs, consumer GPUs, and Apple Silicon under one
reproducible workload suite (`suite-v1`).

Why it fits this list:
- **Reproducible**: open-source CLI (`pipx install llm-speed`) runs the
  same workload pack on any machine; every published number links
  back to the run record that produced it.
- **Trust chain**: dual-domain SHA-256 sidecar (CDN + GitHub Releases),
  Apache-2.0, public source at github.com/meadow-kun/llm-speed.
- **Open data**: every submission is JWS-signed and queryable via
  `https://api.llm-speed.com/v1/results`.

Following existing format / position. Happy to adjust the blurb or
section if you'd prefer a different fit.
