### PR TITLE
Add Oodle AI to the list of AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Manifold](https://github.com/uber/manifold) - A model-agnostic visual debugging tool for machine learning.
 * [NannyML](https://github.com/NannyML/nannyml) - Algorithm capable of fully capturing the impact of data drift on performance.
 * [Netron](https://github.com/lutzroeder/netron) - Visualizer for neural network, deep learning, and machine learning models.
+* [Oodle AI](https://oodle.ai/) - AI-native observability platform with agent tracing, evals, prompt management. Compatible with OpenTelemetry GenAI Conventions.
 * [Opik](https://github.com/comet-ml/opik) - Evaluate, test, and ship LLM applications with a suite of observability tools.
 * [Phoenix](https://phoenix.arize.com) - MLOps in a Notebook for troubleshooting and fine-tuning generative LLM, CV, and tabular models.
 * [Radicalbit](https://github.com/radicalbit/radicalbit-ai-monitoring/) - The open source solution for monitoring your AI models in production.


### PR DESCRIPTION
## What is this tool for?

AI-native observability platform with agent tracing, evals, prompt management. Compatible with OpenTelemetry GenAI Conventions.

## What's the difference between this tool and similar ones?

Advantages:
- 10x cheaper than competitors - thanks to S3-based data store
- Insights for finding anomalous traces at scale - with 0$ in token costs
- Out-of-the-box sentiment analysis - understand which agent session frustrate users the most, and why

Similar to Langfuse, Arize AI, Langsmith, Datadog LLM Observability

URL for details: https://www.oodle.ai/product/agent-observability

---

Anyone who agrees with this pull request could submit an *Approve* review to it.
