### PR TITLE
Add traceburn

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Radicalbit](https://github.com/radicalbit/radicalbit-ai-monitoring/) - The open source solution for monitoring your AI models in production.
 * [Rhesis](https://github.com/rhesis-ai/rhesis) - Testing infrastructure for LLM and agentic applications with collaborative evaluation.
 * [Superwise](https://www.superwise.ai) - Fully automated, enterprise-grade model observability in a self-service SaaS platform.
+* [traceburn](https://github.com/TommyTranX/traceburn) - Local-first cost and efficiency profiler for AI agents that finds and quantifies wasted LLM spend, with a printed mechanical fix for two of the waste patterns.
 * [Whylogs](https://github.com/whylabs/whylogs) - The open source standard for data logging. Enables ML monitoring and observability.
 * [Yellowbrick](https://github.com/DistrictDataLabs/yellowbrick) - Visual analysis and diagnostic tools to facilitate machine learning model selection.
 


### PR DESCRIPTION
Adds traceburn to Visual Analysis and Debugging.

traceburn is a local-first, MIT-licensed cost and efficiency profiler for AI agents built on the openai and anthropic Python SDKs (plus litellm). It finds and quantifies wasted LLM spend, such as duplicate calls, missed prompt caching, context bloat, model overkill, and retry loops, and for two of those five patterns it prints the mechanical fix. Everything runs against one local SQLite file with no account or server required.

Repo: https://github.com/TommyTranX/traceburn