### PR TITLE
Add whatbroke

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Radicalbit](https://github.com/radicalbit/radicalbit-ai-monitoring/) - The open source solution for monitoring your AI models in production.
 * [Rhesis](https://github.com/rhesis-ai/rhesis) - Testing infrastructure for LLM and agentic applications with collaborative evaluation.
 * [Superwise](https://www.superwise.ai) - Fully automated, enterprise-grade model observability in a self-service SaaS platform.
+* [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) - Diff an AI agent's behavior between two runs, including tool calls, arguments, cost and latency.
 * [Whylogs](https://github.com/whylabs/whylogs) - The open source standard for data logging. Enables ML monitoring and observability.
 * [Yellowbrick](https://github.com/DistrictDataLabs/yellowbrick) - Visual analysis and diagnostic tools to facilitate machine learning model selection.
 


### PR DESCRIPTION
Adding whatbroke to Visual Analysis and Debugging, in alphabetical order. It is a CLI I built that diffs an AI agent's behavior between two runs, covering tool calls, arguments, cost and latency, with importers for OTLP GenAI spans, Langfuse and LangSmith exports. MIT licensed, one link, no trailing whitespace.