### PR TITLE
Add truescore

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Deepchecks](https://github.com/deepchecks/deepchecks) - Open-source package for validating ML models & data, with various checks and suites.
 * [Starwhale](https://github.com/star-whale/starwhale) - An MLOps/LLMOps platform for model building, evaluation, and fine-tuning.
 * [Trubrics](https://github.com/trubrics/trubrics-sdk) - Validate machine learning with data science and domain expert feedback.
+* [truescore](https://github.com/SaifPunjwani/truescore) - Statistical validation of LLM-judge scores: bias correction, confidence intervals, and model comparisons.
 
 ## Optimization Tools
 


### PR DESCRIPTION
## What is this tool for?

truescore is a Python library and CLI for the statistics of LLM-judged evaluations. Given judge verdicts on a full eval set plus human labels on a subset, it uses prediction-powered inference to correct the reported score and produce a confidence interval, measures judge agreement (sensitivity/specificity, Cohen's kappa, Gwet's AC1, Krippendorff's alpha), tests whether the judge is biased by response length, self-preference or answer position, compares two models with McNemar and paired bootstrap, and gives per-segment results with Holm/BH multiplicity control. It also has anytime-valid confidence sequences for continuously monitored evals, judge-drift detection against an anchor set, contamination testing, and labeling-budget planning. `truescore doctor file.csv` profiles an eval file and reports which of those are computable from the columns present.

## What's the difference between this tool and similar ones?

Deepchecks and Trubrics validate models and data; truescore validates the *measurement* — it takes the output of whatever eval harness or judge you already run and asks whether the number is right. It never calls a model and is not an eval runner or a judge. In the example shipped with the repo (simulated data, so ground truth is known), the judge reports a 0.8383 pass rate against a true 0.7140 and its interval excludes the truth, while the corrected estimate covers it. Apache-2.0, numpy and scipy are the only dependencies, 602 tests including Monte Carlo interval-coverage simulations, mypy --strict, and a CLI with distinct exit codes so a CI job can gate on a finding.
