### PR TITLE
Add telemetry.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Radicalbit](https://github.com/radicalbit/radicalbit-ai-monitoring/) - The open source solution for monitoring your AI models in production.
 * [Rhesis](https://github.com/rhesis-ai/rhesis) - Testing infrastructure for LLM and agentic applications with collaborative evaluation.
 * [Superwise](https://www.superwise.ai) - Fully automated, enterprise-grade model observability in a self-service SaaS platform.
+* [telemetry.dev](https://telemetry.dev) - OpenTelemetry-native observability for LLM and agent apps with per-span tokens, cost, and latency.
 * [Whylogs](https://github.com/whylabs/whylogs) - The open source standard for data logging. Enables ML monitoring and observability.
 * [Yellowbrick](https://github.com/DistrictDataLabs/yellowbrick) - Visual analysis and diagnostic tools to facilitate machine learning model selection.
 


### PR DESCRIPTION
## What is this tool for?

telemetry.dev is observability for LLM and agent applications, built on OpenTelemetry. It records per-span token counts, cost, and latency, so you can see what each model call in a trace actually spent. Cost is computed server-side from real token usage rather than estimated client-side.

## What's the difference between this tool and similar ones?

It is OTel-native instead of a proprietary SDK, so any OTLP/HTTP exporter can send data to it and there is no vendor-specific instrumentation to adopt. This section already lists commercial platforms such as Aporia, Arize, Fiddler, and Superwise; telemetry.dev sits in that group but is scoped to LLM and agent traces.

Disclosure: I built telemetry.dev.
