### PR TITLE
Add vLLM deployment tutorial to Model Serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving) - Flexible, high-performance serving system for ML models, designed for production.
 * [TorchServe](https://github.com/pytorch/serve) - A flexible and easy to use tool for serving PyTorch models.
 * [Triton Inference Server](https://github.com/triton-inference-server/server) - Provides an optimized cloud and edge inferencing solution.
+* [vLLM Tutorial: How to Deploy and Serve LLMs](https://packet.ai/blog/vllm-tutorial-deploy-serve-llms-gpu-cloud) - Practical guide to deploying and serving LLMs with vLLM, covering configuration, GPU selection, and production setup.
 * [Vespa](https://github.com/vespa-engine/vespa) - Store, search, organize and make machine-learned inferences over big data at serving time.
 * [Wallaroo.AI](https://wallaroo.ai/) - A platform for deploying, serving, and optimizing ML models in both cloud and edge environments.
 


### PR DESCRIPTION
Adds a practical vLLM deployment tutorial to the Model Serving section.

The tutorial covers:

- Deploying vLLM on GPU infrastructure
- Continuous batching and PageAttention
- GPU sizing (H100, H200, B200)
- Multi-GPU tensor parallelism
- Quantization strategies (FP8, AWQ, GPTQ)
- Production deployment best practices

The guide is focused on practitioners looking to deploy and serve LLMs with vLLM in production.