### PR TITLE
Add flameox

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Dask](https://dask.org/) - Provides advanced parallelism for analytics, enabling performance at scale for the tools you love.
 * [DeepSpeed](https://github.com/microsoft/DeepSpeed) - Deep learning optimization library that makes distributed training easy, efficient, and effective.
 * [Fiber](https://uber.github.io/fiber/) - Python distributed computing library for modern computer clusters.
+* [flameox](https://github.com/morluto/flameox) - Profiling and optimization toolkit for agents that captures PyTorch traces, compares runs, and investigates GPU kernels and inference workloads.
 * [Horovod](https://github.com/horovod/horovod) - Distributed deep learning training framework for TensorFlow, Keras, PyTorch, and Apache MXNet.
 * [Mahout](https://mahout.apache.org/) - Distributed linear algebra framework and mathematically expressive Scala DSL.
 * [MLlib](https://spark.apache.org/mllib/) - Apache Spark's scalable machine learning library.


### PR DESCRIPTION
Adds flameox to Optimization Tools.

flameox gives agents bounded CLI and MCP operations to capture PyTorch traces, compare runs, and investigate GPU-kernel and inference-workload performance evidence.

Validation: `git diff --check`.