### PR TITLE
Add TokenGauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [Radicalbit](https://github.com/radicalbit/radicalbit-ai-monitoring/) - The open source solution for monitoring your AI models in production.
 * [Rhesis](https://github.com/rhesis-ai/rhesis) - Testing infrastructure for LLM and agentic applications with collaborative evaluation.
 * [Superwise](https://www.superwise.ai) - Fully automated, enterprise-grade model observability in a self-service SaaS platform.
+* [TokenGauge](https://tokengauge.enby.fish/) - Compare official LLM API rates, model workload costs, and quality-adjusted token-saving experiments.
 * [Whylogs](https://github.com/whylabs/whylogs) - The open source standard for data logging. Enables ML monitoring and observability.
 * [Yellowbrick](https://github.com/DistrictDataLabs/yellowbrick) - Visual analysis and diagnostic tools to facilitate machine learning model selection.
 


### PR DESCRIPTION
## What changed

Adds one alphabetized TokenGauge link to the existing Visual Analysis and Debugging section.

TokenGauge compares dated official LLM API rates, models workload costs, and supports quality-adjusted token-saving experiments.

## Validation

- `python3 check_order.py` passes
- The linked production page returns HTTP 200
- `git diff --check` passes

I maintain TokenGauge. This contribution was prepared with AI assistance.