### PR TITLE
Add Scrollcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [PredictionIO](https://github.com/apache/predictionio) - Event collection, deployment of algorithms, evaluation, querying predictive results via APIs.
 * [Quix](https://quix.io) - Serverless platform for processing data streams in real-time with machine learning models.
 * [Rune](https://github.com/hotg-ai/rune) - Provides containers to encapsulate and deploy EdgeML pipelines and applications.
+* [Scrollcase](https://scrollcase.dev) - Packs a Python environment and its model into a signed, self-contained archive that runs without Docker.
 * [Seldon](https://www.seldon.io/) - Take your ML projects from POC to production with maximum efficiency and minimal risk.
 * [Streamlit](https://github.com/streamlit/streamlit) - Lets you create apps for your ML projects with deceptively simple Python scripts.
 * [TensorFlow Serving](https://www.tensorflow.org/tfx/guide/serving) - Flexible, high-performance serving system for ML models, designed for production.


### PR DESCRIPTION
I'm the author of Scrollcase, flagging that up front.

It packs a Python environment together with the model it runs into a single self-contained archive. The receiving machine extracts it and runs it — no Python install, no `pip install`, no compiler, no container runtime. The build is deterministic (rebuilding the same commit gives a byte-identical archive) and every archive ships with an Ed25519-signed release document, so whoever receives it can verify offline that it's the one you built.

I put it in **Model Serving**, next to Cog and Rune: it addresses the same "get this model onto someone else's machine" problem, minus the container. Placed alphabetically between Rune and Seldon, and `check_order.py` passes locally.

- Docs: https://scrollcase.dev
- Repo: https://github.com/suffro/scrollcase (Apache-2.0, macOS/Linux/Windows, CPU and CUDA)

Happy to move it to a different section or reword the description if you'd rather.